### PR TITLE
Implementation of the physics informed generator learning using kernel methods

### DIFF
--- a/docs/bibliography.bib
+++ b/docs/bibliography.bib
@@ -179,3 +179,10 @@ series = {NIPS'18}
   year = {2023},
   copyright = {arXiv.org perpetual,  non-exclusive license}
 }
+@inproceedings{kostic2024learning,
+title={Learning the Infinitesimal Generator of Stochastic Diffusion Processes},
+author={Vladimir R Kostic and H{\'e}l{\`e}ne Halconruy and Timoth{\'e}e Devergne and Karim Lounici and Massimiliano Pontil},
+booktitle={The Thirty-eighth Annual Conference on Neural Information Processing Systems},
+year={2024},
+url={https://openreview.net/forum?id=H7SaaqfCUi}
+}

--- a/docs/reference/kernel.rst
+++ b/docs/reference/kernel.rst
@@ -39,7 +39,7 @@ Reduced Rank
 
 .. autofunction:: linear_operator_learning.kernel.rand_reduced_rank
 
-.. autofunction:: linear_operator_learning.kernel.physics_informed_reduced_rank_regression
+.. autofunction:: linear_operator_learning.kernel.reduced_rank_regression_physics_informed
 
 .. _pcr:
 Principal Component Regression

--- a/docs/reference/kernel.rst
+++ b/docs/reference/kernel.rst
@@ -20,9 +20,15 @@ Inference
 
 .. autofunction:: linear_operator_learning.kernel.predict
 
+.. autofunction:: linear_operator_learning.kernel.predict_physics_informed
+
 .. autofunction:: linear_operator_learning.kernel.eig
 
+.. autofunction:: linear_operator_learning.kernel.eig_physics_informed
+
 .. autofunction:: linear_operator_learning.kernel.evaluate_eigenfunction
+
+.. autofunction:: linear_operator_learning.kernle.evaluate_right_eigenfunction_physics_informed
 
 .. _rrr:
 Reduced Rank
@@ -32,6 +38,8 @@ Reduced Rank
 .. autofunction:: linear_operator_learning.kernel.nystroem_reduced_rank
 
 .. autofunction:: linear_operator_learning.kernel.rand_reduced_rank
+
+.. autofunction:: linear_operator_learning.kernel.physics_informed_reduced_rank_regression
 
 .. _pcr:
 Principal Component Regression
@@ -59,5 +67,16 @@ Linear Algebra Utilities
 .. autofunction:: linear_operator_learning.kernel.linalg.stable_topk
 
 .. autofunction:: linear_operator_learning.kernel.linalg.add_diagonal_
+
+
+.. _kernel_derivatives:
+Kernel Derivatives
+~~~~~~~~~~~~~~~~~~~~~~~~
+.. autofunction:: linear_operator_learning.kernel.return_phi_dphi
+
+.. autofunction:: linear_operator_learning.kernel.return_dphi_dphi
+
+Bibliography
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. footbibliography::

--- a/linear_operator_learning/kernel/__init__.py
+++ b/linear_operator_learning/kernel/__init__.py
@@ -2,3 +2,4 @@
 
 from linear_operator_learning.kernel.linalg import *  # noqa
 from linear_operator_learning.kernel.regressors import *  # noqa
+from linear_operator_learning.kernel.utils import *  # noqa

--- a/linear_operator_learning/kernel/linalg.py
+++ b/linear_operator_learning/kernel/linalg.py
@@ -73,7 +73,7 @@ def eig_physics_informed(
     fit_result: FitResult,
     shift: float,
 ) -> EigResult:
-    """Computes the eigendecomposition of the infinitesimal generator operator.
+    """Computes the eigendecomposition of the infinitesimal generator operator (see :footcite:t:`kostic2024learning`).
 
     Args:
         fit_result (FitResult): Fit result as defined in ``operator_learning.structs``.
@@ -132,11 +132,11 @@ def evaluate_eigenfunction(
 def evaluate_right_eigenfunction_physics_informed(
     kernel_X: np.ndarray, dKernel_X: np.ndarray, eig_result: np.ndarray, shift: float
 ):
-    r"""Fits the physics informed Reduced Rank Estimator.
+    r"""Evaluates the right eigenfunction of the physics informed generator ( see :footcite:t:`kostic2024learning`).
 
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
-        dKernel_X (np.ndarray): (matrix N in the paper) derivative of the kernel: N{i,(k-1)n+j} = <\phi(x_i),d_k\phi(x_j)>
+        dKernel_X (np.ndarray): (matrix N in :footcite:t:`kostic2024learning`) derivative of the kernel: N{i,(k-1)n+j} = <\phi(x_i),d_k\phi(x_j)>
         eig_result: EigResult object containing eigendecomposition results
         shift (float): shift parameter of the resolvent
 

--- a/linear_operator_learning/kernel/linalg.py
+++ b/linear_operator_learning/kernel/linalg.py
@@ -10,7 +10,12 @@ from numpy import ndarray
 from linear_operator_learning.kernel.structs import EigResult, FitResult
 from linear_operator_learning.kernel.utils import sanitize_complex_conjugates, topk
 
-__all__ = ["eig", "evaluate_eigenfunction"]
+__all__ = [
+    "eig",
+    "evaluate_eigenfunction",
+    "eig_physics_informed",
+    "evaluate_right_eigenfunction_physics_informed",
+]
 
 
 def eig(
@@ -131,12 +136,13 @@ def evaluate_right_eigenfunction_physics_informed(
 
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
-        dKernel_X (np.ndarray): derivative of the kernel: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
+        dKernel_X (np.ndarray): (matrix N in the paper) derivative of the kernel: N{i,(k-1)n+j} = <\phi(x_i),d_k\phi(x_j)>
         eig_result: EigResult object containing eigendecomposition results
         shift (float): shift parameter of the resolvent
 
     Shape:
         ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
+
         ``dkernel_X``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
 
     Returns:

--- a/linear_operator_learning/kernel/regressors.py
+++ b/linear_operator_learning/kernel/regressors.py
@@ -14,11 +14,13 @@ from linear_operator_learning.kernel.structs import FitResult
 
 __all__ = [
     "predict",
+    "predict_physics_informed",
     "pcr",
     "nystroem_pcr",
     "reduced_rank",
     "nystroem_reduced_rank",
     "rand_reduced_rank",
+    "physics_informed_reduced_rank_regression",
 ]
 
 
@@ -72,7 +74,7 @@ def predict_physics_informed(
     Args:
         eig_result: EigResult object containing reduced rank regression results
         kernel_obs (np.ndarray): kernel matrix of the initial conditions and the training set
-        dKernel_obs (np.ndarray): derivative of the kernel between the initial condition and the training set: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
+        dKernel_obs (np.ndarray): (matrix N in the paper) derivative of the kernel between the initial condition and the training set: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
         obs_train_X (ndarray): Observable evaluated on output training data (or inducing points for Nystroem)
         shift (float): shift parameter of the resolvent
         time (float): time at which we want to estimate the prediction
@@ -80,7 +82,7 @@ def predict_physics_informed(
     Shape:
         ``kernel_obs``: :math:`(N, N)`, where :math:`N` is the number of training data.
 
-        ``dkernel_obs``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
+        ``dkernel_obs``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math:`d` is the dimensionality of the input data.
 
         ``obs_train_X``: :math:`(N, *)`, where :math:`*` is the shape of the observable.
 
@@ -446,8 +448,8 @@ def physics_informed_reduced_rank_regression(
 
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
-        dKernel_X (np.ndarray): derivative of the kernel: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
-        dKernel_dX (np.ndarray):  derivative of the kernel dK_dX_{i,j} = <d\phi(x_i),d\phi(x_j)> (matrix M in the paper)
+        dKernel_X (np.ndarray): (matrix N in the paper) derivative of the kernel: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
+        dKernel_dX (np.ndarray):  (matrix M in the paper) derivative of the kernel :math:`M_{(l-1)n+i,(k-1)n+j} = \langle d_l\phi(x_i),d_k\phi(x_j) \rangle`
         shift (float): shift parameter of the resolvent
         tikhonov_reg (float): Tikhonov (ridge) regularization parameter
         rank (int): Rank of the estimator
@@ -455,8 +457,9 @@ def physics_informed_reduced_rank_regression(
     Shape:
         ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
 
-        ``dkernel_X``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
-        ``dkernel_dX``: :math:`((d+1)N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
+        ``dkernel_X``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math:`d` is the dimensionality of the input data.
+
+        ``dkernel_dX``: :math:`((d+1)N, (d+1)N)`. where :math:`N` is the number of training data amd :math:`d` is the dimensionality of the input data.
     Returns: FitResult structure containing `U` and `V` matrices
     """
     npts = kernel_X.shape[0]

--- a/linear_operator_learning/kernel/regressors.py
+++ b/linear_operator_learning/kernel/regressors.py
@@ -59,6 +59,47 @@ def predict(
     return np.linalg.multi_dot([K_dot_U, M, V_dot_obs])
 
 
+def predict_physics_informed(
+    eig_result: FitResult,
+    kernel_obs: np.ndarray,
+    dKernel_obs: np.ndarray,
+    obs_train_X: np.ndarray,
+    shift: float,
+    time: float,
+) -> np.ndarray:
+    r"""Predicts future states using kernel matrices and fitted results.
+
+    Args:
+        eig_result: EigResult object containing reduced rank regression results
+        kernel_obs (np.ndarray): kernel matrix of the initial conditions and the training set
+        dKernel_obs (np.ndarray): derivative of the kernel between the initial condition and the training set: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
+        obs_train_X (ndarray): Observable evaluated on output training data (or inducing points for Nystroem)
+        shift (float): shift parameter of the resolvent
+        time (float): time at which we want to estimate the prediction
+
+    Shape:
+        ``kernel_obs``: :math:`(N, N)`, where :math:`N` is the number of training data.
+
+        ``dkernel_obs``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
+
+        ``obs_train_X``: :math:`(N, *)`, where :math:`*` is the shape of the observable.
+
+        Output: :math:`(N, *)`.
+    """
+    ul = eig_result["left"]
+    ur = eig_result["right"]
+    evs = eig_result["values"]
+    npts = kernel_obs.shape[0]
+    h = (np.sqrt(shift) * (kernel_obs @ ur[:npts, :]) + (dKernel_obs @ ur[npts:, :])) / np.sqrt(
+        npts
+    )
+    g = np.sqrt(shift) * obs_train_X @ ul
+
+    pred = (np.exp(evs * time)[np.newaxis, :] * (g[np.newaxis, :] * h)).sum(axis=-1)
+
+    return pred
+
+
 def pcr(
     kernel_X: ndarray,
     tikhonov_reg: float = 0.0,
@@ -390,4 +431,72 @@ def rand_reduced_rank(
     V = sqrt(npts) * _M @ vectors
     svals = np.sqrt(values)
     result: FitResult = {"U": U, "V": V, "svals": svals}
+    return result
+
+
+def physics_informed_reduced_rank_regression(
+    kernel_X: np.ndarray,  # kernel matrix of the training data
+    dKernel_X: np.ndarray,  # derivative of the kernel: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
+    dKernel_dX: np.ndarray,  # derivative of the kernel dK_dX_{i,j} = <d\phi(x_i),d\phi(x_j)>
+    shift: float,  # shift parameter of the resolvent
+    tikhonov_reg: float,  # Tikhonov (ridge) regularization parameter, can be 0,
+    rank: int,
+):  # Rank of the estimator)
+    r"""Fits the physics informed Reduced Rank Estimator.
+
+    Args:
+        kernel_X (np.ndarray): kernel matrix of the training data
+        dKernel_X (np.ndarray): derivative of the kernel: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
+        dKernel_dX (np.ndarray):  derivative of the kernel dK_dX_{i,j} = <d\phi(x_i),d\phi(x_j)> (matrix M in the paper)
+        shift (float): shift parameter of the resolvent
+        tikhonov_reg (float): Tikhonov (ridge) regularization parameter
+        rank (int): Rank of the estimator
+
+    Shape:
+        ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
+
+        ``dkernel_X``: :math:`(N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
+        ``dkernel_dX``: :math:`((d+1)N, (d+1)N)`. where :math:`N` is the number of training data amd :math: `d` is the dimensionality of the input data.
+    Returns: FitResult structure containing `U` and `V` matrices
+    """
+    npts = kernel_X.shape[0]
+    sqrt_npts = np.sqrt(npts)
+
+    dimension_derivative = dKernel_dX.shape[0]
+
+    # We follow the notation of the paper
+    J = (
+        kernel_X / sqrt_npts
+        - (dKernel_X / sqrt_npts)
+        @ np.linalg.inv(
+            dKernel_dX + tikhonov_reg * shift * sqrt_npts * np.eye(dimension_derivative)
+        )
+        @ dKernel_X.T
+    )
+
+    sigmas_2, vectors = eigs(
+        J @ kernel_X / sqrt_npts, k=rank + 5, M=(J + tikhonov_reg * np.eye(J.shape[0])) * shift
+    )
+
+    values, stable_values_idxs = stable_topk(sigmas_2, rank, ignore_warnings=False)
+
+    V = vectors[:, stable_values_idxs]
+    # Normalization step
+    V = V @ np.diag(np.sqrt(sqrt_npts) / np.sqrt(np.diag(V.T @ kernel_X @ V)))
+
+    sigma = np.diag(sigmas_2[stable_values_idxs])
+
+    make_U = np.block(
+        [
+            np.eye(npts) / np.sqrt(shift),
+            -dKernel_X
+            @ np.linalg.inv(
+                dKernel_dX + shift * tikhonov_reg * sqrt_npts * np.eye(dimension_derivative)
+            ),
+        ]
+    ).T
+
+    U = make_U @ (kernel_X @ V / sqrt_npts - shift * V @ sigma) / (tikhonov_reg * shift)
+    result: FitResult = {"U": U.real, "V": V.real, "svals": np.sqrt(sigmas_2[stable_values_idxs])}
+
     return result

--- a/linear_operator_learning/kernel/regressors.py
+++ b/linear_operator_learning/kernel/regressors.py
@@ -69,12 +69,12 @@ def predict_physics_informed(
     shift: float,
     time: float,
 ) -> np.ndarray:
-    r"""Predicts future states using kernel matrices and fitted results.
+    r"""Predicts future states using kernel matrices and fitted results using a physics informed generator from :footcite:t:`kostic2024learning`.
 
     Args:
         eig_result: EigResult object containing reduced rank regression results
         kernel_obs (np.ndarray): kernel matrix of the initial conditions and the training set
-        dKernel_obs (np.ndarray): (matrix N in the paper) derivative of the kernel between the initial condition and the training set: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
+        dKernel_obs (np.ndarray): (matrix N in :footcite:t:`kostic2024learning`) derivative of the kernel between the initial condition and the training set: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
         obs_train_X (ndarray): Observable evaluated on output training data (or inducing points for Nystroem)
         shift (float): shift parameter of the resolvent
         time (float): time at which we want to estimate the prediction
@@ -444,12 +444,12 @@ def physics_informed_reduced_rank_regression(
     tikhonov_reg: float,  # Tikhonov (ridge) regularization parameter, can be 0,
     rank: int,
 ):  # Rank of the estimator)
-    r"""Fits the physics informed Reduced Rank Estimator.
+    r"""Fits the physics informed Reduced Rank Estimator from :footcite:t:`kostic2024learning`.
 
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
-        dKernel_X (np.ndarray): (matrix N in the paper) derivative of the kernel: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
-        dKernel_dX (np.ndarray):  (matrix M in the paper) derivative of the kernel :math:`M_{(l-1)n+i,(k-1)n+j} = \langle d_l\phi(x_i),d_k\phi(x_j) \rangle`
+        dKernel_X (np.ndarray): (matrix N in :footcite:t:`kostic2024learning`) derivative of the kernel: :math:`N_{i,(k-1)n+j} = \langle \phi(x_i),d_k\phi(x_j) \rangle`
+        dKernel_dX (np.ndarray):  (matrix M in :footcite:t:`kostic2024learning`) derivative of the kernel :math:`M_{(l-1)n+i,(k-1)n+j} = \langle d_l\phi(x_i),d_k\phi(x_j) \rangle`
         shift (float): shift parameter of the resolvent
         tikhonov_reg (float): Tikhonov (ridge) regularization parameter
         rank (int): Rank of the estimator

--- a/linear_operator_learning/kernel/regressors.py
+++ b/linear_operator_learning/kernel/regressors.py
@@ -20,7 +20,7 @@ __all__ = [
     "reduced_rank",
     "nystroem_reduced_rank",
     "rand_reduced_rank",
-    "physics_informed_reduced_rank_regression",
+    "reduced_rank_regression_physics_informed",
 ]
 
 
@@ -436,7 +436,7 @@ def rand_reduced_rank(
     return result
 
 
-def physics_informed_reduced_rank_regression(
+def reduced_rank_regression_physics_informed(
     kernel_X: np.ndarray,  # kernel matrix of the training data
     dKernel_X: np.ndarray,  # derivative of the kernel: dK_X_{i,j} = <\phi(x_i),d\phi(x_j)> (matrix N in the paper)
     dKernel_dX: np.ndarray,  # derivative of the kernel dK_dX_{i,j} = <d\phi(x_i),d\phi(x_j)>

--- a/linear_operator_learning/kernel/utils.py
+++ b/linear_operator_learning/kernel/utils.py
@@ -70,7 +70,7 @@ def return_phi_dphi(
     sigma: float,
     friction: np.ndarray,
 ):
-    r"""Returns the matrix :math:`N_{i,(k-1)n+j}=<\phi(x_i),d_k\phi(x_j)>` (matrix :math:`N` in the paper) only for
+    r"""Returns the matrix :math:`N_{i,(k-1)n+j}=<\phi(x_i),d_k\phi(x_j)>` (matrix :math:`N` :footcite:t:`kostic2024learning`) only for
     a GAUSSIAN kernel
     where :math:`i = 1,\dots n, k=1, \dots d, j=1,\dots n`
     and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system.
@@ -79,7 +79,7 @@ def return_phi_dphi(
         kernel_X (np.ndarray): kernel matrix of the training data
         X (np.ndarray): training data
         sigma (float): length scale of the GAUSSIAN kernel
-        friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in the paper
+        friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in :footcite:t:`kostic2024learning`
     Shape:
         ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
 
@@ -103,7 +103,7 @@ def return_phi_dphi(
 
 
 def return_dphi_dphi(kernel_X: np.ndarray, X: np.ndarray, sigma: float, friction: np.ndarray):
-    r"""Returns the matrix :math:`M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` (matrix :math:`M` in the paper) only for
+    r"""Returns the matrix :math:`M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` (matrix :math:`M` in :footcite:t:`kostic2024learning`) only for
     a GAUSSIAN kernel
     where :math:`i = 1,\dots n, k=1, \dots d, j=1,\dots n, l=1, \dots d`
     and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system.
@@ -112,7 +112,7 @@ def return_dphi_dphi(kernel_X: np.ndarray, X: np.ndarray, sigma: float, friction
         kernel_X (np.ndarray): kernel matrix of the training data
         X (np.ndarray): training data
         sigma (float): length scale of the GAUSSIAN kernel
-        friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in the paper
+        friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in :footcite:t:`kostic2024learning`
     Shape:
         ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
         ``X``: :math:`(N,d)`  where :math:`N` is the number of training data and `d` the dimensionality of the system.

--- a/linear_operator_learning/kernel/utils.py
+++ b/linear_operator_learning/kernel/utils.py
@@ -6,6 +6,11 @@ import numpy as np
 from numpy import ndarray
 from scipy.spatial.distance import pdist
 
+__all__ = [
+    "return_phi_dphi",
+    "return_dphi_dphi",
+]
+
 
 def topk(vec: ndarray, k: int):
     """Get the top k values from a Numpy array.
@@ -65,20 +70,24 @@ def return_phi_dphi(
     sigma: float,
     friction: np.ndarray,
 ):
-    r"""Returns the matrix :math: `N_{i,(k-1)n+j}=<\phi(x_i),d_k\phi(x_j)>` (matrix :math:`N` in the paper) only for
+    r"""Returns the matrix :math:`N_{i,(k-1)n+j}=<\phi(x_i),d_k\phi(x_j)>` (matrix :math:`N` in the paper) only for
     a GAUSSIAN kernel
     where :math:`i = 1,\dots n, k=1, \dots d, j=1,\dots n`
-    and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system
+    and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system.
+
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
         X (np.ndarray): training data
         sigma (float): length scale of the GAUSSIAN kernel
         friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in the paper
     Shape:
-        ``kernel_X`` `: :math:`(N, N)`, where :math:`N` is the number of training data.
-        ``X``: :math: `(N,d)`  where :math:`N` is the number of training data and `d` the dimensionality of the system.
-        ``friction``: :math: `d`  where :math:`d` is the dimensionality of the system.
-    Output: :math:`<\phi(x_i),d_k\phi(x_j)>` of shape `N,Nd`, where :math:`N` is the number of training data and :math: `d` the dimension of the system.
+        ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
+
+        ``X``: :math:`(N,d)`  where :math:`N` is the number of training data and :math:`d` the dimensionality of the system.
+
+        ``friction``: :math:`d`  where :math:`d` is the dimensionality of the system.
+
+    Output: :math:`<\phi(x_i),d_k\phi(x_j)>` of shape `N,Nd`, where :math:`N` is the number of training data and :math:`d` the dimension of the system.
     """  # noqa: D205
     difference = X[:, np.newaxis, :] - X[np.newaxis, :, :]
     n = difference.shape[0]
@@ -94,20 +103,21 @@ def return_phi_dphi(
 
 
 def return_dphi_dphi(kernel_X: np.ndarray, X: np.ndarray, sigma: float, friction: np.ndarray):
-    r"""Returns the matrix :math: `M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` (matrix :math:`n` in the paper) only for
+    r"""Returns the matrix :math:`M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` (matrix :math:`M` in the paper) only for
     a GAUSSIAN kernel
     where :math:`i = 1,\dots n, k=1, \dots d, j=1,\dots n, l=1, \dots d`
-    and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system
+    and :math:`N` is the number of training points and :math:`d` is the dimensionality of the system.
+
     Args:
         kernel_X (np.ndarray): kernel matrix of the training data
         X (np.ndarray): training data
         sigma (float): length scale of the GAUSSIAN kernel
         friction (np.ndarray): friction parameter of the physical model :math:`s(x)` in the paper
     Shape:
-        ``kernel_X`` `: :math:`(N, N)`, where :math:`N` is the number of training data.
-        ``X``: :math: `(N,d)`  where :math:`N` is the number of training data and `d` the dimensionality of the system.
-        ``friction``: :math: `d`  where :math:`d` is the dimensionality of the system
-    Returns: :math:`M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` of shape `N,Nd`, where :math:`N` is the number of training data and :math: `d` the dimension of the system.
+        ``kernel_X``: :math:`(N, N)`, where :math:`N` is the number of training data.
+        ``X``: :math:`(N,d)`  where :math:`N` is the number of training data and `d` the dimensionality of the system.
+        ``friction``: :math:`d`  where :math:`d` is the dimensionality of the system
+    Returns: :math:`M_{(k-1)n + i,(l-1)n+j}=<d_k\phi(x_i),d_l\phi(x_j)>` of shape `N,Nd`, where :math:`N` is the number of training data and :math:`d` the dimension of the system.
     """  # noqa: D205
     difference = X[:, np.newaxis, :] - X[np.newaxis, :, :]
 


### PR DESCRIPTION
1. Reduced rank regression (reduced_rank_regression_physics_informed in kernels/regressors.py)
2. Eigenfunction utilities (evaluate_right_eigenfunctions_physics_informed (the left one is the same as for other methods and it seemed a mess to implement both in the same function) in kernels/linalg.py)
3. Prediction (predict_physics_informed in kernels/regressors.py)
4. Some derivative utilities, only for gaussian kernels in utils.py

Normally, I updated the doc. Let me know if you see anything or want me to change something.  